### PR TITLE
Removed piece of code that hid the frame on mac?!

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [4.3.1] - 2020-12-14
+MacOS can move the window!
+
+## Fixed
+- Monthlong bug where you cant move the window with a one line change :)
+
 ## [4.3.0] - 2020-12-04
 Google broke some things and there was some other stuff that has always been broken.
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "android-messages-desktop",
   "description": "Messages for web, as a desktop app",
-  "version": "4.3.0",
+  "version": "4.3.1",
   "author": {
     "name": "Kyle Rosenberg",
     "email": "kyle@ekrosenberg.com"

--- a/src/background.ts
+++ b/src/background.ts
@@ -151,7 +151,6 @@ if (!isFirstInstance) {
       height: 800,
       autoHideMenuBar: settingsManager.autoHideMenu,
       show: !settingsManager.startInTray, //Starts in tray if set
-      titleBarStyle: IS_MAC ? "hiddenInset" : "default", //Turn on hidden frame on a Mac
       icon: IS_LINUX
         ? path.resolve(RESOURCES_PATH, "icons", "128x128.png")
         : undefined,


### PR DESCRIPTION
Found piece of code explicitly hiding the window frame on macos. I do not know why that decision was made but it has been removed. If I could get some help testing this it would be awesome!

Links will be provided to a download once CI runs.

Closes #164 