### PR TITLE
Tooltip on tray icon

### DIFF
--- a/src/helpers/trayManager.ts
+++ b/src/helpers/trayManager.ts
@@ -136,6 +136,7 @@ export class TrayManager {
 
   public setUnreadIcon(toggle: boolean): void {
     if (this.tray && this.overlayIconPath != null) {
+      this.tray.setToolTip("Android Messages");
       if (toggle) {
         this.tray.setImage(this.overlayIconPath);
       } else {


### PR DESCRIPTION
Tray icon should always have identification of what application it belongs to.