### PR TITLE
No window shown if tray disabled and AMD not linked to a phone

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -190,9 +190,6 @@ if (!isFirstInstance) {
 
       state.bridgeInitDone = true;
 
-      // a work around issue #229 (https://github.com/OrangeDrangon/android-messages-desktop/issues/229)
-      if (!settingsManager.startInTray) mainWindow.show();
-
       // We have to send un-solicited events (i.e. an event not the result of an event sent to this process) to the webview bridge
       // via the renderer process. I'm not sure of a way to get a reference to the androidMessagesWebview inside the renderer from
       // here. There may be a legit way to do it, or we can do it a dirty way like how we pass this process to the renderer.

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -6,6 +6,7 @@ import {
   SETTING_HIDE_NOTIFICATION,
   RESOURCES_PATH,
   SETTING_NOTIFICATION_SOUND,
+  SETTING_START_IN_TRAY,
 } from "./helpers/constants";
 import { handleEnterPrefToggle } from "./helpers/inputManager";
 import { popupContextMenu } from "./menu/contextMenu";

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -58,6 +58,9 @@ window.addEventListener("load", () => {
     childList: true,
     attributes: true,
   });
+
+  // a work around issue #229 (https://github.com/OrangeDrangon/android-messages-desktop/issues/229)
+  if (!settings.get(SETTING_START_IN_TRAY)) app.mainWindow?.show();
 });
 
 ipcRenderer.on(EVENT_UPDATE_USER_SETTING, (_event, settingsList) => {


### PR DESCRIPTION
Fix for https://github.com/vanowm/android-messages-desktop/commit/3b9ba0141598bf144fb57bcbb64a8fac5578277f
(#229)