### PR TITLE
Remove titlebar on macos

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -71,6 +71,7 @@ app.on("ready", () => {
     icon: IS_LINUX
       ? path.resolve(RESOURCES_PATH, "icons", "128x128.png")
       : undefined,
+    titleBarStyle: IS_MAC ? "hiddenInset" : "default",
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false,

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -1,6 +1,10 @@
 import { ipcRenderer } from "electron";
 import path from "path";
-import { INITIAL_ICON_IMAGE, RESOURCES_PATH } from "./helpers/constants";
+import {
+  INITIAL_ICON_IMAGE,
+  IS_MAC,
+  RESOURCES_PATH,
+} from "./helpers/constants";
 import {
   createRecentThreadObserver,
   createUnreadObserver,
@@ -10,6 +14,29 @@ import {
 import { getProfileImg } from "./helpers/profileImage";
 
 window.addEventListener("load", () => {
+  if (true) {
+    const titlebarStyle = `#amd-titlebar {
+      -webkit-app-region: drag;
+      position: fixed;
+      width: 100%;
+      height: 64px;
+      top: 0;
+      left: 0;
+      background: none;
+      pointer-events: none;
+    }`;
+
+    document.body.appendChild(
+      Object.assign(document.createElement("style"), {
+        textContent: titlebarStyle,
+      })
+    );
+
+    const titlebar = document.createElement("div");
+    titlebar.id = "amd-titlebar";
+    document.querySelector("mw-app")?.parentNode?.prepend(titlebar);
+  }
+
   const conversationListObserver = new MutationObserver(() => {
     if (document.querySelector("mws-conversations-list") != null) {
       createUnreadObserver();

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -14,7 +14,7 @@ import {
 import { getProfileImg } from "./helpers/profileImage";
 
 window.addEventListener("load", () => {
-  if (true) {
+  if (IS_MAC) {
     const titlebarStyle = `#amd-titlebar {
       -webkit-app-region: drag;
       position: fixed;


### PR DESCRIPTION
The current change just removes the frame. It does not mark any draggable regions. If the frame is gone and you cannot move the window we can work towards marking a good location as draggable.