### PR TITLE
Update User Agent for Firefox 117

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -91,7 +91,7 @@ if (gotTheLock) {
 
     // set user agent to potentially make google fi work
     const userAgent =
-      "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:108.0) Gecko/20100101 Firefox/108.0";
+      "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:109.0) Gecko/20100101 Firefox/117.0";
 
     mainWindow.webContents.session.webRequest.onBeforeSendHeaders(
       {


### PR DESCRIPTION
I've updated the user agent again so that Google doesn't start saying that the application is insecure when trying to login to Fi.