### PR TITLE
Modifying handleTrayClick to minimize when window is visible

### DIFF
--- a/src/helpers/trayManager.ts
+++ b/src/helpers/trayManager.ts
@@ -149,7 +149,15 @@ export class TrayManager {
 
   private handleTrayClick() {
     const mainWindow = getMainWindow();
-    mainWindow?.show();
+    if (!mainWindow)
+      return;
+
+    if (mainWindow.isVisible()) {
+      mainWindow.hide();
+    }
+    else {
+      mainWindow.show();
+    }
   }
 
   private destroy(): void {

--- a/src/helpers/trayManager.ts
+++ b/src/helpers/trayManager.ts
@@ -154,8 +154,7 @@ export class TrayManager {
 
     if (mainWindow.isVisible()) {
       mainWindow.hide();
-    }
-    else {
+    } else {
       mainWindow.show();
     }
   }


### PR DESCRIPTION
Very minor modification made to `handleTrayClick` to check if the window is visible before showing or hiding.

Note that the original enhancement calls for also bringing the window to the top/focus if it is hidden behind another window, but the page visibility API only allows that level of granularity (tracking if the window is occluded by another window) on macOS: https://www.electronjs.org/docs/latest/api/browser-window#page-visibility

On other platforms it will just show/hide based on minimized/visible.

Closes #412 