### PR TITLE
add a cmd+w shortcut for closing the window

### DIFF
--- a/src/menu/appMenu.ts
+++ b/src/menu/appMenu.ts
@@ -17,6 +17,9 @@ export const appMenuTemplate: MenuItemConstructorOptions = {
     separator,
     settingsMenu,
     separator,
+    { 
+      role: 'close',
+    },
     {
       label: "Hide Android Messages Desktop",
       accelerator: "Command+H",


### PR DESCRIPTION
This is a solution to [issue 377](https://github.com/OrangeDrangon/android-messages-desktop/issues/377#issuecomment-2388537473)