### PR TITLE
Adds WMClass Property to .desktop File

### DIFF
--- a/electron-builder.js
+++ b/electron-builder.js
@@ -17,6 +17,12 @@ export default {
       "--gtk-version=3",
     ],
     category: "Internet",
+    desktop: {
+      entry: {
+        Name: "Android Messages Desktop",
+        StartupWMClass: "android-messages-desktop",
+      },
+    },
   },
   win: {
     target: ["nsis", "portable"],

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,3 @@
 [tools]
+github-cli = "latest"
 node = "lts"


### PR DESCRIPTION
The mismatch of the application WM_CLASS with the `.desktop` file was preventing the correct icon from displaying for me in GNOME on Arch. 

Related to and should also fix #457