### PR TITLE
fix: invalid desktop file entries on Gnome

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -17,11 +17,11 @@ export default {
   linux: {
     target: ["AppImage", "deb", "pacman", "rpm", "freebsd", "zip"],
     executableName: "AndroidMessages",
-    category: "Internet",
+    category: "Network",
     desktop: {
       entry: {
         Name: "Android Messages Desktop",
-        StartupWMClass: "android-messages-desktop",
+        StartupWMClass: "AndroidMessages",
       },
     },
   },


### PR DESCRIPTION
Closes #527 

As far as I can tell from building locally, these changes only affect the desktop file.