### PR TITLE
Report initial unread status when observer starts

### DIFF
--- a/src/preload/observers.ts
+++ b/src/preload/observers.ts
@@ -19,6 +19,7 @@ export function createUnreadObserver(): MutationObserver {
       attributeFilter: ["data-e2e-is-unread"],
     }
   );
+  unreadObserver();
   return observer;
 }
 


### PR DESCRIPTION
## Summary
- send the current unread status immediately after the unread observer starts
- fixes startup cases where Messages loads with an existing unread conversation but no unread attribute mutation occurs

## Testing
- pnpm/webpack production build: background:
  asset background.js 14.8 KiB [emitted] [minimized] (name: main) 1 related asset
  orphan modules 27.3 KiB [orphan] 31 modules
  runtime modules 663 bytes 3 modules
  ./src/background.ts + 31 modules 35.1 KiB [not cacheable] [built] [code generated]
  background (webpack 5.106.2) compiled successfully in 1509 ms

bridge:
  asset bridge.js 7.61 KiB [emitted] [minimized] (name: main) 1 related asset
  orphan modules 3.91 KiB [orphan] 4 modules
  ./src/bridge.ts + 4 modules 10.2 KiB [not cacheable] [built] [code generated]
  bridge (webpack 5.106.2) compiled successfully in 1408 ms