### PR TITLE
Add one-time code copy action for message notifications

### DIFF
--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -30,6 +30,9 @@ export default {
   },
   mac: {
     category: "public.app-category.social-networking",
+    extendInfo: {
+      NSUserNotificationAlertStyle: "alert",
+    },
     target: { target: "default", arch: "universal" },
   },
   portable: {

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,11 @@
-import { app, Event as ElectronEvent, ipcMain, shell } from "electron";
+import {
+  app,
+  clipboard,
+  Event as ElectronEvent,
+  ipcMain,
+  Notification,
+  shell,
+} from "electron";
 import { BrowserWindow } from "electron/main";
 import path from "path";
 import process from "process";
@@ -205,6 +212,46 @@ if (gotTheLock) {
   ipcMain.on("should-hide-notification-content", (event) => {
     event.returnValue = settings.hideNotificationContentEnabled.value;
   });
+
+  ipcMain.on("should-auto-copy-otp", (event) => {
+    event.returnValue = settings.autoCopyOtpEnabled.value;
+  });
+
+  ipcMain.on("copy-otp-to-clipboard", (_event, otp: string) => {
+    clipboard.writeText(otp);
+  });
+
+  ipcMain.on(
+    "show-otp-notification",
+    (
+      _event,
+      {
+        title,
+        body,
+        otp,
+        hideContent,
+      }: { title: string; body: string; otp: string; hideContent: boolean }
+    ) => {
+      const notification = new Notification({
+        title: hideContent ? "New Message" : title,
+        body: hideContent ? "Click to open" : body,
+        icon: path.resolve(RESOURCES_PATH, "icons", "64x64.png"),
+        actions: [{ type: "button", text: "Copy OTP" }],
+        closeButtonText: "Close",
+      });
+
+      notification.on("click", () => {
+        mainWindow.show();
+        mainWindow.focus();
+      });
+
+      notification.on("action", () => {
+        clipboard.writeText(otp);
+      });
+
+      notification.show();
+    }
+  );
 
   ipcMain.on("show-main-window", () => {
     mainWindow.show();

--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -95,6 +95,20 @@ contextBridge.exposeInMainWorld("interop", {
   should_hide: () => {
     return ipcRenderer.sendSync("should-hide-notification-content");
   },
+  should_auto_copy_otp: () => {
+    return ipcRenderer.sendSync("should-auto-copy-otp");
+  },
+  copy_otp_to_clipboard: (otp: string) => {
+    ipcRenderer.send("copy-otp-to-clipboard", otp);
+  },
+  show_otp_notification: (data: {
+    title: string;
+    body: string;
+    otp: string;
+    hideContent: boolean;
+  }) => {
+    ipcRenderer.send("show-otp-notification", data);
+  },
   get_icon: async () => {
     const data =  await ipcRenderer.invoke("get-icon");
     return `data:image/png;base64,${data}`;
@@ -108,9 +122,67 @@ webFrame.executeJavaScript(`
   });
 `);
 webFrame.executeJavaScript(`window.OldNotification = window.Notification;
+function normalizeOtpCandidate(candidate) {
+  const otp = String(candidate || "").replace(/[\\s-]/g, "");
+  if (!/\\d/.test(otp)) return null;
+  if (!/^[A-Za-z0-9]{4,8}$/.test(otp)) return null;
+  if (/^(?:19|20)\\d{2}$/.test(otp)) return null;
+  if (/^(.)\\1+$/.test(otp)) return null;
+  return otp;
+}
+
+function extractOtpFromText(text) {
+  const value = String(text || "");
+  const keyword = "(?:otp|one[-\\\\s]?time|verification|verify|security|login|sign[-\\\\s]?in|authentication|auth|passcode|pin|code)";
+  const candidate = "([A-Za-z0-9](?:[A-Za-z0-9-]{2,10}[A-Za-z0-9])?)";
+  const explicitPatterns = [
+    new RegExp("(?:^|\\\\n)@[^\\\\s]+\\\\s+#" + candidate + "\\\\s*$", "i"),
+    new RegExp("\\\\b(?:" + keyword + ")\\\\b(?:\\\\s+(?:is|for|=|:|-|to use|is:))*\\\\s+" + candidate + "\\\\b", "i"),
+    new RegExp("\\\\b" + candidate + "\\\\b\\\\s+(?:is|=)\\\\s+(?:your\\\\s+)?(?:" + keyword + ")\\\\b", "i"),
+    new RegExp("\\\\b(?:use|enter|type)\\\\s+" + candidate + "\\\\b.{0,40}\\\\b(?:" + keyword + ")\\\\b", "i"),
+  ];
+  const keywordPattern = new RegExp("\\\\b" + keyword + "\\\\b", "gi");
+  const tokenPattern = /\\b[A-Za-z0-9](?:[A-Za-z0-9-]{2,10}[A-Za-z0-9])?\\b/g;
+  let keywordMatch;
+
+  for (const pattern of explicitPatterns) {
+    const otp = normalizeOtpCandidate(value.match(pattern)?.[1]);
+    if (otp) return otp;
+  }
+
+  while ((keywordMatch = keywordPattern.exec(value)) != null) {
+    const windowStart = Math.max(0, keywordMatch.index - 50);
+    const windowEnd = Math.min(value.length, keywordMatch.index + keywordMatch[0].length + 100);
+    const nearbyText = value.slice(windowStart, windowEnd);
+    const tokens = nearbyText.match(tokenPattern) || [];
+
+    for (const token of tokens) {
+      const otp = normalizeOtpCandidate(token);
+      if (otp) return otp;
+    }
+  }
+
+  return null;
+}
+
 window.Notification = function (title, options) {
   try {
     const hideContent = window.interop.should_hide();
+    const autoCopyOtp = window.interop.should_auto_copy_otp();
+    const otp = extractOtpFromText(options?.body);
+    if (otp) {
+      if (autoCopyOtp) {
+        window.interop.copy_otp_to_clipboard(otp);
+      }
+      window.interop.show_otp_notification({
+        title,
+        body: options?.body || "",
+        otp,
+        hideContent,
+      });
+      window.interop.flash_main();
+      return;
+    }
 
     const notificationOpts = hideContent
       ? {

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -47,6 +47,7 @@ export interface JsonSettings {
   isUpdate: boolean;
   taskbarFlashEnabled: boolean;
   trayIconRedDotEnabled: boolean;
+  autoCopyOtpEnabled: boolean;
 }
 
 // wraps json settings in the setting type for export
@@ -79,6 +80,7 @@ const defaultSettings: JsonSettings = {
   isUpdate: false,
   taskbarFlashEnabled: true,
   trayIconRedDotEnabled: true,
+  autoCopyOtpEnabled: false,
 };
 
 // create default settings file if it doesnt exist

--- a/src/menu/settingsMenu.ts
+++ b/src/menu/settingsMenu.ts
@@ -14,6 +14,7 @@ const {
   showIconsInRecentConversationTrayEnabled,
   trayIconRedDotEnabled,
   taskbarFlashEnabled,
+  autoCopyOtpEnabled,
 } = settings;
 
 export const settingsMenu: MenuItemConstructorOptions = {
@@ -92,6 +93,13 @@ export const settingsMenu: MenuItemConstructorOptions = {
       type: "checkbox",
       checked: taskbarFlashEnabled.value,
       click: (item) => taskbarFlashEnabled.next(item.checked),
+    },
+    {
+      id: "autoCopyOtpEnabledMenuItem",
+      label: "Automatically Copy One-Time Codes",
+      type: "checkbox",
+      checked: autoCopyOtpEnabled.value,
+      click: (item) => autoCopyOtpEnabled.next(item.checked),
     },
     separator,
     {


### PR DESCRIPTION
## Summary
- detects one-time codes from message notification bodies only
- adds an opt-in setting to automatically copy detected one-time codes
- shows native OTP notifications with a Copy OTP action button when a code is detected
- sets macOS notification alert style so action buttons can be shown

## Notes
- sender/title text is intentionally ignored for OTP extraction because short-code senders can look like OTPs
- parser handles common OTP formats, hyphenated codes, Google-style codes, and WebOTP-style `@domain #code` endings

## Testing
- pnpm/webpack production build: `./node_modules/.bin/webpack --mode=production`
- manually tested with a Google Messages OTP notification body
