### PR TITLE
Fix macOS titlebar layout

### DIFF
--- a/src/bridge.ts
+++ b/src/bridge.ts
@@ -20,15 +20,42 @@ declare global {
 const preload_init = () => {
 
     if (IS_MAC) {
-      const titlebarStyle = `#amd-titlebar {
+      const titlebarStyle = `:root {
+        --amd-titlebar-height: 28px;
+      }
+
+      body {
+        overflow: hidden;
+      }
+
+      mw-app {
+        display: block;
+        height: calc(100vh - var(--amd-titlebar-height));
+        overflow: hidden;
+        transform: translateY(var(--amd-titlebar-height));
+      }
+
+      #amd-titlebar {
         -webkit-app-region: drag;
         position: fixed;
-        width: 100%;
-        height: 64px;
+        height: var(--amd-titlebar-height);
         top: 0;
         left: 0;
+        right: 0;
         background: none;
         pointer-events: none;
+        z-index: 2147483647;
+      }
+
+      button,
+      a,
+      input,
+      textarea,
+      select,
+      [role="button"],
+      [role="link"],
+      [tabindex] {
+        -webkit-app-region: no-drag;
       }`;
 
       document.body.appendChild(


### PR DESCRIPTION
## Summary

On macOS, the native traffic-light window controls share space with the embedded Google Messages web UI. The current preload styling leaves the Google Messages header at the very top of the window, so the header sits inside the draggable titlebar/traffic-light area instead of below it.

That makes the top Google Messages controls unreliable: the hamburger menu can be visually crowded/cut off by the macOS controls and is not clickable, and the Google Account photo on the right also appears clickable but does not respond because it is inside the drag region.

This reserves a small macOS-only titlebar strip above the Google Messages content and shifts the full `mw-app` down by that amount. Keeping the whole web UI below the native controls fixes both hit targets without manually repositioning Google Messages' internal header controls, while still leaving a draggable region for the frameless window.

- add a macOS-only titlebar inset before the Google Messages web UI
- shift the full Messages app content below the native traffic-light controls
- restore clickability for the hamburger menu and Google Account photo
- keep interactive page controls marked as non-draggable while preserving a draggable titlebar strip

## Screenshots

Before:

![Before macOS titlebar overlap](https://raw.githubusercontent.com/jaredjxyz/android-messages-desktop/pr-assets/macos-titlebar-layout/.github/pr-assets/macos-titlebar-layout/before.png)

After:

![After macOS titlebar layout](https://raw.githubusercontent.com/jaredjxyz/android-messages-desktop/pr-assets/macos-titlebar-layout/.github/pr-assets/macos-titlebar-layout/after.png)

## Testing

- `./node_modules/.bin/webpack --mode=production`
- built and launched the macOS app locally
- verified the native window controls no longer overlap the Google Messages hamburger/header area
