### PR TITLE
Tidy up the recent-conversations tray menu

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -17,6 +17,13 @@ export const SETTINGS_FILE = (): string => {
   return path.resolve(app.getPath("userData"), `settings.json`);
 };
 
+// Tray
+/**
+ * Logical size (in points) that recent-conversation avatars are resized to in
+ * the tray menu so every row has a uniform, compact height.
+ */
+export const TRAY_AVATAR_SIZE = 28;
+
 // UUID
 /**
  * An arbitrary v4 uuid generated on https://www.uuidgenerator.net/version4

--- a/src/helpers/trayManager.ts
+++ b/src/helpers/trayManager.ts
@@ -13,6 +13,7 @@ import {
   IS_MAC,
   IS_WINDOWS,
   RESOURCES_PATH,
+  TRAY_AVATAR_SIZE,
   UUID_NAMESPACE,
 } from "./constants";
 import { settings } from "./settings";
@@ -98,7 +99,9 @@ export class TrayManager {
           image != null &&
           image != INITIAL_ICON_IMAGE &&
           showIconsInRecentConversationTrayEnabled.value
-            ? nativeImage.createFromDataURL(image)
+            ? nativeImage
+                .createFromDataURL(image)
+                .resize({ width: TRAY_AVATAR_SIZE, height: TRAY_AVATAR_SIZE })
             : undefined;
 
         return {

--- a/src/preload/constants_preload.ts
+++ b/src/preload/constants_preload.ts
@@ -4,4 +4,8 @@ export const IS_MAC = window.navigator.userAgent.indexOf("Macintosh") > -1;
 
 export const RECENT_CONVERSATION_TRAY_COUNT = 3;
 
+// Max characters of a conversation snippet shown in the tray before it is
+// truncated with an ellipsis.
+export const RECENT_CONVERSATION_SNIPPET_LENGTH = 30;
+
 export {INITIAL_ICON_IMAGE} from "../helpers/constants_shared";

--- a/src/preload/observers.ts
+++ b/src/preload/observers.ts
@@ -1,5 +1,8 @@
 import { ipcRenderer } from "electron";
-import { RECENT_CONVERSATION_TRAY_COUNT } from "./constants_preload";
+import {
+  RECENT_CONVERSATION_SNIPPET_LENGTH,
+  RECENT_CONVERSATION_TRAY_COUNT,
+} from "./constants_preload";
 
 function unreadObserver() {
   if (document.querySelector(".unread") != null) {
@@ -42,12 +45,16 @@ export function recentThreadObserver() {
 
     const image = canvas?.toDataURL();
 
+    const snippet = conversation
+      .querySelector(
+        "a div.text-content div.snippet-text mws-conversation-snippet span"
+      )
+      ?.textContent?.trim();
+
     const recentMessage =
-      conversation
-        .querySelector(
-          "a div.text-content div.snippet-text mws-conversation-snippet span"
-        )
-        ?.textContent?.slice(0, 20) + "...";
+      snippet && snippet.length > RECENT_CONVERSATION_SNIPPET_LENGTH
+        ? `${snippet.slice(0, RECENT_CONVERSATION_SNIPPET_LENGTH).trimEnd()}…`
+        : snippet;
 
     const focusFunction = () => void conversation.querySelector("a")?.click();
     focusFunctions[i] = focusFunction;


### PR DESCRIPTION
## Overview

The recent-conversations section of the tray menu looked a bit unpolished: avatars were inserted at the source `<canvas>` resolution (≈80px on a HiDPI display), so each row ballooned to the avatar's height and rows had inconsistent sizes.

This PR makes the menu compact and uniform with two small, self-contained changes.

## Changes

- **Uniform avatar size** — each avatar is now resized to a uniform `28×28` before being used as the menu item icon, so every row has the same compact height. The size lives in a named `TRAY_AVATAR_SIZE` constant.
- **Cleaner snippet text** — the conversation preview now:
  - trims surrounding whitespace,
  - only appends an ellipsis (`…`) when the text is actually truncated. Previously `"..."` was appended unconditionally, and conversations with no preview rendered the literal string `"undefined..."`.
  - uses a named `RECENT_CONVERSATION_SNIPPET_LENGTH` constant for the truncation length.

No behavior changes beyond the menu's appearance; `tsc --noEmit` passes.

## Screenshots

_Before:_

<img width="279" height="376" alt="image-1782307304685" src="https://github.com/user-attachments/assets/449633d5-b2fb-4a9a-9640-885e9777dadd" />


_After:_

<img width="263" height="190" alt="image-1782307316826" src="https://github.com/user-attachments/assets/baa1b391-cbf6-4c04-963b-01b8e3037ed3" />

