### PR TITLE
Make the update flow clearer with dialogs and progress

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -2,7 +2,7 @@ import { app, Event as ElectronEvent, ipcMain, shell } from "electron";
 import { BrowserWindow } from "electron/main";
 import path from "path";
 import process from "process";
-import { checkForUpdate } from "./helpers/autoUpdate";
+import { checkForUpdate, setUpdateWindow } from "./helpers/autoUpdate";
 import { IS_DEV, IS_LINUX, IS_MAC, RESOURCES_PATH } from "./helpers/constants";
 import { MenuManager } from "./helpers/menuManager";
 import { setSettingsFlushEnabled, settings } from "./helpers/settings";
@@ -59,10 +59,6 @@ if (gotTheLock) {
 
     new MenuManager();
 
-    if (checkForUpdateOnLaunchEnabled.value && !IS_DEV) {
-      checkForUpdate(true, false);
-    }
-
     const { width, height } = savedWindowSize.value;
     const { x, y } = savedWindowPosition.value ?? {};
 
@@ -90,6 +86,11 @@ if (gotTheLock) {
     });
 
     process.env.MAIN_WINDOW_ID = mainWindow.id.toString();
+
+    setUpdateWindow(mainWindow);
+    if (checkForUpdateOnLaunchEnabled.value && !IS_DEV) {
+      checkForUpdate(false);
+    }
 
     if (!(settings.trayEnabled.value && settings.startInTrayEnabled.value)) {
       mainWindow.show();

--- a/src/helpers/autoUpdate.ts
+++ b/src/helpers/autoUpdate.ts
@@ -1,71 +1,131 @@
 import { autoUpdater } from "electron-updater";
-import { app, Menu, Notification } from "electron";
+import { app, BrowserWindow, dialog } from "electron";
 import path from "path";
 import { IS_DEV, RESOURCES_PATH } from "./constants";
-import { settings } from "./settings";
 
-function setUpdaterSettings(): void {
-  autoUpdater.autoDownload = false;
-  autoUpdater.autoInstallOnAppQuit = false;
+// Updates are fully manual: we never download or install without the user
+// asking. The flow below drives everything off electron-updater's events so we
+// can surface progress and errors instead of failing silently.
+autoUpdater.autoDownload = false;
+autoUpdater.autoInstallOnAppQuit = false;
+
+const icon = (): string => path.resolve(RESOURCES_PATH, "icons", "64x64.png");
+
+// The window used to parent update dialogs and show download progress in the
+// dock/taskbar. Set once the main window exists.
+let updateWindow: BrowserWindow | null = null;
+export function setUpdateWindow(win: BrowserWindow): void {
+  updateWindow = win;
 }
 
-/**
- * Returns true if there is an update.
- */
-export async function checkForUpdate(
-  showUpdateNotification: boolean,
-  showNoUpdateNotification: boolean
-): Promise<boolean> {
-  setUpdaterSettings();
-  const results = await autoUpdater.checkForUpdates().catch(() => null);
-  let isUpdate = false;
-  if (results != null) {
-    console.log(
-      results.updateInfo.version,
-      app.getVersion(),
-      results.updateInfo.version > app.getVersion()
-    );
+// Whether the in-flight check was triggered explicitly by the user (a menu
+// item) rather than the silent check on launch. Both surface the "update
+// available" dialog; only interactive checks also surface "up to date" and
+// error states, so a launch with no network doesn't pop dialogs.
+let interactiveCheck = false;
+// Guards against overlapping checks/downloads if the user clicks repeatedly.
+let busy = false;
 
-    isUpdate = results.updateInfo.version > app.getVersion();
-    if (isUpdate && showUpdateNotification) {
-      const notification = new Notification({
-        title: "Update Available",
-        body:
-          'There is an update available. Click "Install Update"' +
-          " in the file or app menu.",
-        icon: path.resolve(RESOURCES_PATH, "icons", "64x64.png"),
-      });
-      notification.show();
-    } else if (!isUpdate && showNoUpdateNotification) {
-      const notification = new Notification({
-        title: "No update found",
-        icon: path.resolve(RESOURCES_PATH, "icons", "64x64.png"),
-        silent: true,
-        urgency: "low",
-      });
-      notification.show();
-    }
-  }
-  const installUpdateMenuItem = Menu.getApplicationMenu()?.getMenuItemById(
-    "installUpdateMenuItem"
-  );
-  if (installUpdateMenuItem != null) {
-    installUpdateMenuItem.visible = isUpdate;
-  }
-  settings.isUpdate.next(isUpdate);
-  return isUpdate;
+function showDialog(
+  options: Electron.MessageBoxOptions
+): Promise<Electron.MessageBoxReturnValue> {
+  return updateWindow
+    ? dialog.showMessageBox(updateWindow, options)
+    : dialog.showMessageBox(options);
 }
 
-/**
- * Checks for update, downloads, quits, and installs app.
- */
-export async function installUpdate(): Promise<void> {
-  if (!IS_DEV) {
-    setUpdaterSettings();
-    if (await checkForUpdate(false, false)) {
-      await autoUpdater.downloadUpdate();
-      settings.isUpdate.next(false);
-      autoUpdater.quitAndInstall();
-    }
+function setProgress(fraction: number): void {
+  // -1 removes the progress bar.
+  updateWindow?.setProgressBar(fraction);
+}
+
+function reportError(err: unknown): void {
+  setProgress(-1);
+  busy = false;
+  console.error("Update error:", err);
+  if (interactiveCheck) {
+    showDialog({
+      type: "error",
+      title: "Update Error",
+      message: "Couldn't complete the update.",
+      detail: err instanceof Error ? err.message : String(err),
+      icon: icon(),
+    });
   }
+}
+
+autoUpdater.on("update-not-available", () => {
+  busy = false;
+  if (interactiveCheck) {
+    showDialog({
+      type: "info",
+      title: "No Update Found",
+      message: "You're up to date.",
+      detail: `Android Messages Desktop ${app.getVersion()} is the latest version.`,
+      icon: icon(),
+    });
+  }
+});
+
+autoUpdater.on("update-available", async (info) => {
+  const { response } = await showDialog({
+    type: "info",
+    buttons: ["Download & Install", "Later"],
+    defaultId: 0,
+    cancelId: 1,
+    title: "Update Available",
+    message: `Version ${info.version} is available.`,
+    detail: `You're on ${app.getVersion()}. Download and install it now? The app will restart to finish.`,
+    icon: icon(),
+  });
+
+  if (response === 0) {
+    setProgress(2); // indeterminate until the first progress event arrives
+    autoUpdater.downloadUpdate().catch(reportError);
+  } else {
+    busy = false;
+  }
+});
+
+autoUpdater.on("download-progress", (progress) => {
+  setProgress(progress.percent / 100);
+});
+
+autoUpdater.on("update-downloaded", async (info) => {
+  setProgress(-1);
+  const { response } = await showDialog({
+    type: "info",
+    buttons: ["Restart Now", "Later"],
+    defaultId: 0,
+    cancelId: 1,
+    title: "Update Ready",
+    message: `Version ${info.version} has been downloaded.`,
+    detail:
+      "Restart now to finish installing, or it will be installed the next time you quit.",
+    icon: icon(),
+  });
+
+  if (response === 0) {
+    autoUpdater.quitAndInstall();
+  } else {
+    // Install on next quit so the download isn't wasted.
+    autoUpdater.autoInstallOnAppQuit = true;
+    busy = false;
+  }
+});
+
+/**
+ * Checks for an update and, if found, walks the user through downloading and
+ * installing it.
+ *
+ * @param interactive true when the user explicitly asked (shows "up to date"
+ *   and error dialogs); false for the silent check on launch.
+ */
+export function checkForUpdate(interactive: boolean): void {
+  if (IS_DEV || busy) {
+    return;
+  }
+  interactiveCheck = interactive;
+  busy = true;
+  autoUpdater.checkForUpdates().catch(reportError);
 }

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -44,7 +44,6 @@ export interface JsonSettings {
   checkForUpdateOnLaunchEnabled: boolean;
   monochromeIconEnabled: boolean;
   showIconsInRecentConversationTrayEnabled: boolean;
-  isUpdate: boolean;
   taskbarFlashEnabled: boolean;
   trayIconRedDotEnabled: boolean;
 }
@@ -76,7 +75,6 @@ const defaultSettings: JsonSettings = {
   checkForUpdateOnLaunchEnabled: true,
   monochromeIconEnabled: true,
   showIconsInRecentConversationTrayEnabled: true,
-  isUpdate: false,
   taskbarFlashEnabled: true,
   trayIconRedDotEnabled: true,
 };

--- a/src/menu/appMenu.ts
+++ b/src/menu/appMenu.ts
@@ -1,10 +1,7 @@
 import { app, MenuItemConstructorOptions } from "electron";
 import { aboutMenuItem } from "./items/about";
 import { separator } from "./items/separator";
-import {
-  checkForUpdatesMenuItem,
-  installUpdatesMenuItem,
-} from "./items/updates";
+import { checkForUpdatesMenuItem } from "./items/updates";
 import { settingsMenu } from "./settingsMenu";
 
 // This is the "Application" menu, which is only used on macOS
@@ -13,7 +10,6 @@ export const appMenuTemplate: MenuItemConstructorOptions = {
   submenu: [
     aboutMenuItem,
     checkForUpdatesMenuItem,
-    installUpdatesMenuItem,
     separator,
     {
       role: "close",

--- a/src/menu/fileMenu.ts
+++ b/src/menu/fileMenu.ts
@@ -1,15 +1,11 @@
 import { app, MenuItemConstructorOptions } from "electron";
-import {
-  checkForUpdatesMenuItem,
-  installUpdatesMenuItem,
-} from "./items/updates";
+import { checkForUpdatesMenuItem } from "./items/updates";
 import { separator } from "./items/separator";
 
 export const fileMenuTemplate: MenuItemConstructorOptions = {
   label: "&File",
   submenu: [
     checkForUpdatesMenuItem,
-    installUpdatesMenuItem,
     separator,
     {
       label: "Quit Android Messages",

--- a/src/menu/items/updates.ts
+++ b/src/menu/items/updates.ts
@@ -1,20 +1,12 @@
 import { MenuItemConstructorOptions } from "electron";
-import { checkForUpdate, installUpdate } from "../../helpers/autoUpdate";
+import { checkForUpdate } from "../../helpers/autoUpdate";
 import { IS_DEV } from "../../helpers/constants";
-import { settings } from "../../helpers/settings";
 
 export const checkForUpdatesMenuItem: MenuItemConstructorOptions = {
-  label: "Check for Updates",
+  label: "Check for Updates…",
   click: () => {
     if (!IS_DEV) {
-      checkForUpdate(true, true);
+      checkForUpdate(true);
     }
   },
-};
-
-export const installUpdatesMenuItem: MenuItemConstructorOptions = {
-  id: "installUpdateMenuItem",
-  label: "Install Updates",
-  visible: settings.isUpdate.value,
-  click: installUpdate,
 };


### PR DESCRIPTION
## Problem

The current update experience is confusing and can appear to do nothing. It confused me so I ended up downloading the new version and installing it manually instead. 

Confusion points: 

- **Two separate menu items** — "Check for Updates" and a conditionally-visible "Install Updates" that only appears *after* a check finds an update, so it reads like a bug rather than a flow.
- **Silent failures** — `checkForUpdates()` is wrapped in `.catch(() => null)`, so any network/feed error produces zero feedback.
- **Easy-to-miss feedback** — results come through notifications; the "no update" one is `silent` + low-urgency.
- **No download progress** — `installUpdate()` downloads (100+ MB) then quits with nothing on screen.
- **Latent detection bug** — updates are detected with a string compare (`updateInfo.version > app.getVersion()`), which breaks on multi-digit versions (`"6.0.10" > "6.0.9"` is `false`).

## Changes

Reworked around electron-updater's events:

- **One menu item** — "Check for Updates…" drives the whole check → download → install flow. Removed the separate "Install Updates" item.
- **Modal dialogs** instead of notifications for user-initiated checks: "Version X is available — Download & Install / Later", a "you're up to date" dialog, and a real **error dialog** instead of swallowing failures.
- **Visible progress** — downloads drive the dock/taskbar progress bar via `setProgressBar`, then prompt to restart (falling back to install-on-quit if the user defers).
- **Correct detection** — relies on electron-updater's own semver-based `update-available` event instead of the string compare.
- Dropped the now-unused `isUpdate` setting.

The silent launch check now also shows the "update available" dialog (matching the manual check), but stays quiet on "up to date" / errors so a startup with no network doesn't pop dialogs.

## Screenshots

Here's the update dialog that will show up for a user once there's a new version available. 

<img width="379" height="307" alt="image-1782422434548" src="https://github.com/user-attachments/assets/feb60df4-f295-4cb4-adc7-77ee47702846" />

Ignore the version 41. in the test -- it was looking at Electron's version number. 

## Testing

- Production webpack build, `tsc --noEmit`, and eslint all pass.
- Launched against the real GitHub release feed: the launch check fires `update-available` and the new dialog renders correctly.

The download → progress → restart tail was not exercised live (requires a published release newer than the installed version); that path is standard electron-updater event wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)