### PR TITLE
Reload main window after suspend to fix blank screen (#505)

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -1,4 +1,10 @@
-import { app, Event as ElectronEvent, ipcMain, shell } from "electron";
+import {
+  app,
+  Event as ElectronEvent,
+  ipcMain,
+  powerMonitor,
+  shell,
+} from "electron";
 import { BrowserWindow } from "electron/main";
 import path from "path";
 import process from "process";
@@ -200,6 +206,26 @@ if (gotTheLock) {
     });
 
     mainWindow.webContents.on("context-menu", popupContextMenu);
+
+    // The Google Messages web app frequently ends up on a blank white screen
+    // after the machine resumes from suspend: its connection to the phone is
+    // dropped and it doesn't recover on its own. Reloading restores it without
+    // the user needing to manually hit Ctrl+R. See issue #505.
+    powerMonitor.on("resume", () => {
+      if (!mainWindow.isDestroyed()) {
+        mainWindow.webContents.reload();
+      }
+    });
+
+    // The OS can also kill the renderer outright while suspended (memory
+    // reclaim), which leaves the same blank screen. Reload to recover unless it
+    // exited cleanly (e.g. during shutdown).
+    mainWindow.webContents.on("render-process-gone", (_event, details) => {
+      console.log("render-process-gone", details);
+      if (details.reason !== "clean-exit" && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.reload();
+      }
+    });
   });
 
   ipcMain.on("should-hide-notification-content", (event) => {


### PR DESCRIPTION
## Problem

Fixes #505.

The Google Messages web app frequently lands on a blank white screen after the machine resumes from suspend. There are two distinct failure modes behind the same symptom:

1. **Renderer survives but the web app is dead** — the connection to the phone drops during suspend and the page never reconnects on its own. No error event fires, so the user just sees a blank screen until they manually press <kbd>Ctrl</kbd>+<kbd>R</kbd>.
2. **OS kills the renderer during suspend** — under memory pressure the OS reclaims the suspended renderer process, leaving the same blank screen.

This has been reported across Linux, macOS, and Windows 11 in the issue thread.

## Fix

Two recovery handlers in `src/background.ts`:

- **`powerMonitor.on("resume")`** — reloads the page whenever the machine wakes from suspend. This covers failure mode 1, which produces no detectable event, and matches the issue author's preferred approach.
- **`webContents.on("render-process-gone")`** — reloads if the renderer dies for any reason other than a clean exit, covering failure mode 2.

Both guard with `isDestroyed()` so they don't touch the window during shutdown.

## Trade-off

The `resume` handler reloads unconditionally on every wake, even when the app didn't break — a reload is fast and rarely coincides with an in-progress draft, so this is the pragmatic choice the thread is asking for. Only reliably detecting the broken state would require injecting a health-check into the renderer, a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)