### PR TITLE
Feature: Portable Mode - Add local data storage and .zip build

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,13 @@ Download your build from the [releases](https://github.com/OrangeDrangon/android
 
 `scoop bucket add extras && scoop install android-messages`
 
+# Portable Mode (Windows)
+
+To run the application in portable mode:
+1. Download the Windows `.zip` version from the releases page and extract it to your desired location.
+2. Create an empty file named `portable.txt` in the same folder as the executable.
+3. Launch the app. A `data` folder will be automatically created to store your app data and settings in the same folder as the executable.
+
 # Contributions
 
 The code is pretty ugly but getting better every day. Feel free to take a look.

--- a/electron-builder.config.js
+++ b/electron-builder.config.js
@@ -25,7 +25,7 @@ export default {
     },
   },
   win: {
-    target: ["nsis", "portable"],
+    target: ["nsis", "portable", "zip"],
   },
   mac: {
     category: "public.app-category.social-networking",

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,3 +1,4 @@
+import "./helpers/portable";
 import { app, Event as ElectronEvent, ipcMain, shell } from "electron";
 import { BrowserWindow } from "electron/main";
 import path from "path";

--- a/src/helpers/portable.ts
+++ b/src/helpers/portable.ts
@@ -1,0 +1,12 @@
+import { app } from "electron";
+import path from "path";
+import fs from "fs";
+import process from "process";
+
+const exeDir = process.env.PORTABLE_EXECUTABLE_DIR || path.dirname(app.getPath("exe"));
+const portablePath = path.join(exeDir, "portable.txt");
+
+if (fs.existsSync(portablePath)) {
+  const dataPath = path.join(exeDir, "data");
+  app.setPath("userData", dataPath);
+}


### PR DESCRIPTION
Adds a portable mode to store user data locally.

Portable mode is enabled by creating a `.txt` file named `portable.txt` in the same folder as the executable. When portable mode is enabled, application data will be stored in a `data` folder in the same location as the executable.

A `.zip` build is also added as an additional way to download the application, and is also arguably the ideal format for a portable installation. This avoids some quirks of the other build formats:
* The `.portable.exe` build self-extracts to `%TEMP%` (which Windows Defender sometimes blocks), and using environment variables is not quite ideal for fully portable installations.
* The standard installation `.exe` creates registry entries and shortcuts.

**Changes:**
- `src/helpers/portable.ts` (New file): Checks for `portable.txt`. If present, all application data is read from and written to a local `data` folder instead of `%APPDATA%`.
- `src/background.ts` (Line 1): Imports the helper to run before the app initializes.
- `electron-builder.config.js` (Line 28): Adds a `.zip` target. Useful for a clean portable version without `%TEMP%` extraction or registry/shortcut installation.
- `README.md` (Lines 32-38): Adds instructions on how to enable portable mode.

I've only tested these changes on Windows 11. If these changes aren't suitable for other operating systems, I believe you could add an `if` statement in the `portable.ts` file so the changes only effect Windows users.

```
if (process.platform === "win32") {
  // code block
}
```
