### PR TITLE
Add menu option to toggle spell checking

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -17,6 +17,7 @@ const {
   savedWindowPosition,
   checkForUpdateOnLaunchEnabled,
   taskbarFlashEnabled,
+  spellCheckEnabled,
 } = settings;
 
 let mainWindow: BrowserWindow;
@@ -100,6 +101,11 @@ if (gotTheLock) {
     trayManager.startIfEnabled();
     settings.showIconsInRecentConversationTrayEnabled.subscribe(() =>
       trayManager.refreshTrayMenu()
+    );
+
+    // Apply the spell-check preference on launch and whenever it is toggled.
+    spellCheckEnabled.subscribe((enabled) =>
+      mainWindow.webContents.session.setSpellCheckerEnabled(enabled)
     );
 
     let quitViaContext = false;

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -47,6 +47,7 @@ export interface JsonSettings {
   isUpdate: boolean;
   taskbarFlashEnabled: boolean;
   trayIconRedDotEnabled: boolean;
+  spellCheckEnabled: boolean;
 }
 
 // wraps json settings in the setting type for export
@@ -79,6 +80,7 @@ const defaultSettings: JsonSettings = {
   isUpdate: false,
   taskbarFlashEnabled: true,
   trayIconRedDotEnabled: true,
+  spellCheckEnabled: true,
 };
 
 // create default settings file if it doesnt exist

--- a/src/menu/settingsMenu.ts
+++ b/src/menu/settingsMenu.ts
@@ -14,6 +14,7 @@ const {
   showIconsInRecentConversationTrayEnabled,
   trayIconRedDotEnabled,
   taskbarFlashEnabled,
+  spellCheckEnabled,
 } = settings;
 
 export const settingsMenu: MenuItemConstructorOptions = {
@@ -92,6 +93,13 @@ export const settingsMenu: MenuItemConstructorOptions = {
       type: "checkbox",
       checked: taskbarFlashEnabled.value,
       click: (item) => taskbarFlashEnabled.next(item.checked),
+    },
+    {
+      id: "spellCheckEnabledMenuItem",
+      label: "Enable Spell Checking",
+      type: "checkbox",
+      checked: spellCheckEnabled.value,
+      click: (item) => spellCheckEnabled.next(item.checked),
     },
     separator,
     {


### PR DESCRIPTION
## Summary

Adds an **"Enable Spell Checking"** checkbox to the Settings/Preferences menu, addressing #584 — there was previously no way to turn off the red squiggle under misspelled words.

The preference defaults to **on** (no behavior change for existing users) and is wired through the existing RxJS settings pattern:

- `spellCheckEnabled` setting added to `settings.ts` (persisted to `settings.json`).
- Checkbox menu item added to `settingsMenu.ts`.
- `background.ts` subscribes to the setting and calls `session.setSpellCheckerEnabled(...)`, so it applies on launch and live on toggle — no restart needed.

Disabling spell checking removes the squiggle and, accordingly, the right-click spelling suggestions / "Add to Dictionary" entries, which is the standard behavior for a single spell-check switch.

## Testing

Verified against the real Electron runtime by driving the compiled `settings` + `settingsMenu` modules and the `background.ts` wiring:

- Menu item present, labelled "Enable Spell Checking", checkbox type, checked by default.
- Toggling the item flips both the setting and `session.isSpellCheckerEnabled()` in both directions.
- The value is persisted to `settings.json`.
- Full app boots cleanly with the new menu item (no startup errors).

Closes #584

🤖 Generated with [Claude Code](https://claude.com/claude-code)